### PR TITLE
Add controller action tests

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -40,8 +40,10 @@
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
         @routes
-        @viteReactRefresh
-        @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+        @unless(app()->environment('testing'))
+            @viteReactRefresh
+            @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+        @endunless
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/tests/Feature/FeatureControllerTest.php
+++ b/tests/Feature/FeatureControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Project;
+use App\Models\Feature;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FeatureControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createProject(User $user): Project
+    {
+        return Project::create([
+            'project_number' => 'PRJ-' . uniqid(),
+            'name' => 'Projekt',
+            'description' => 'Desc',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'created_by' => $user->id,
+        ]);
+    }
+
+    public function test_feature_list_is_displayed()
+    {
+        $user = User::factory()->create();
+        $project = $this->createProject($user);
+        Feature::create([
+            'jira_key' => 'FEA-001',
+            'name' => 'Feature',
+            'project_id' => $project->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('features.index', absolute: false));
+        $response->assertOk();
+    }
+
+    public function test_feature_can_be_created()
+    {
+        $user = User::factory()->create();
+        $project = $this->createProject($user);
+
+        $response = $this->actingAs($user)->post(route('features.store', absolute: false), [
+            'jira_key' => 'FEA-002',
+            'name' => 'Neues Feature',
+            'description' => 'Desc',
+            'project_id' => $project->id,
+            'requester_id' => $user->id,
+        ]);
+
+        $response->assertRedirect(route('features.index', absolute: false));
+
+        $this->assertDatabaseHas('features', [
+            'jira_key' => 'FEA-002',
+            'name' => 'Neues Feature',
+            'project_id' => $project->id,
+        ]);
+    }
+
+    public function test_feature_can_be_updated()
+    {
+        $user = User::factory()->create();
+        $project = $this->createProject($user);
+        $feature = Feature::create([
+            'jira_key' => 'FEA-003',
+            'name' => 'Altes Feature',
+            'project_id' => $project->id,
+        ]);
+
+        $response = $this->actingAs($user)->put(route('features.update', $feature, false), [
+            'jira_key' => 'FEA-003',
+            'name' => 'Aktualisiertes Feature',
+            'description' => null,
+            'project_id' => $project->id,
+            'requester_id' => $user->id,
+        ]);
+
+        $response->assertRedirect(route('features.index', absolute: false));
+
+        $this->assertDatabaseHas('features', [
+            'id' => $feature->id,
+            'name' => 'Aktualisiertes Feature',
+        ]);
+    }
+
+    public function test_feature_can_be_deleted()
+    {
+        $user = User::factory()->create();
+        $project = $this->createProject($user);
+        $feature = Feature::create([
+            'jira_key' => 'FEA-004',
+            'name' => 'Löschen',
+            'project_id' => $project->id,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('features.destroy', $feature, false));
+
+        $response->assertRedirect(route('features.index', absolute: false));
+
+        $this->assertModelMissing($feature);
+    }
+}

--- a/tests/Feature/ProjectControllerTest.php
+++ b/tests/Feature/ProjectControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_page_is_displayed_for_authenticated_user()
+    {
+        $user = User::factory()->create();
+        Project::create([
+            'project_number' => 'PRJ-001',
+            'name' => 'Demo Projekt',
+            'description' => 'Beschreibung',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'created_by' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('projects.index', absolute: false));
+
+        $response->assertOk();
+    }
+
+    public function test_project_can_be_created()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('projects.store', absolute: false), [
+            'project_number' => 'PRJ-002',
+            'name' => 'Neues Projekt',
+            'description' => 'Test',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'deputy_leader_id' => null,
+        ]);
+
+        $response->assertRedirect(route('projects.index', absolute: false));
+
+        $this->assertDatabaseHas('projects', [
+            'project_number' => 'PRJ-002',
+            'name' => 'Neues Projekt',
+            'created_by' => $user->id,
+        ]);
+    }
+
+    public function test_project_can_be_updated()
+    {
+        $user = User::factory()->create();
+        $project = Project::create([
+            'project_number' => 'PRJ-003',
+            'name' => 'Altes Projekt',
+            'description' => 'Alt',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'created_by' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->put(route('projects.update', $project, false), [
+            'project_number' => 'PRJ-003',
+            'name' => 'Aktualisiertes Projekt',
+            'description' => 'Neu',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'deputy_leader_id' => null,
+        ]);
+
+        $response->assertRedirect(route('projects.index', absolute: false));
+
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'name' => 'Aktualisiertes Projekt',
+        ]);
+    }
+
+    public function test_project_can_be_deleted()
+    {
+        $user = User::factory()->create();
+        $project = Project::create([
+            'project_number' => 'PRJ-004',
+            'name' => 'Zu löschen',
+            'description' => 'Alt',
+            'start_date' => now()->toDateString(),
+            'project_leader_id' => $user->id,
+            'created_by' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->delete(route('projects.destroy', $project, false));
+
+        $response->assertRedirect(route('projects.index', absolute: false));
+
+        $this->assertModelMissing($project);
+    }
+}


### PR DESCRIPTION
## Summary
- adjust layout to skip vite in testing environment
- add tests for `FeatureController` actions
- add tests for `ProjectController` actions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68496bd356808325824b2c1c60359ca6