### PR TITLE
Display and filter feature status when editing planning

### DIFF
--- a/app/Http/Controllers/PlanningController.php
+++ b/app/Http/Controllers/PlanningController.php
@@ -120,7 +120,15 @@ class PlanningController extends Controller
     public function edit(Planning $planning)
     {
         $users = User::all(['id', 'name', 'email']); // E-Mail für alle Benutzer hinzugefügt
-        $features = Feature::where('project_id', $planning->project_id)->get(); // Features des Projekts laden
+        $features = Feature::where('project_id', $planning->project_id)
+            ->get()
+            ->map(fn($feature) => [
+                'id' => $feature->id,
+                'jira_key' => $feature->jira_key,
+                'name' => $feature->name,
+                'project_id' => $feature->project_id,
+                'status_details' => $feature->status_details,
+            ])->values(); // Features des Projekts laden
 
         return Inertia::render('plannings/edit', [
             'planning' => $planning->load([

--- a/resources/js/pages/plannings/edit.tsx
+++ b/resources/js/pages/plannings/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import AppLayout from "@/layouts/app-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +30,7 @@ interface Project {
 interface User {
   id: number;
   name: string;
+  email: string;
 }
 
 interface Feature {
@@ -37,6 +38,11 @@ interface Feature {
   jira_key: string;
   name: string;
   project_id: number;
+  status_details?: {
+    value: string;
+    name: string;
+    color: string;
+  };
 }
 
 interface Planning {
@@ -87,6 +93,28 @@ export default function Edit({
       ? planning.features.map((f) => String(f.id))
       : [],
   });
+
+  const [featureStatusFilter, setFeatureStatusFilter] = useState<string>("");
+
+  const statusOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    features.forEach((f) => {
+      if (f.status_details) {
+        map.set(f.status_details.value, f.status_details.name);
+      }
+    });
+    return Array.from(map.entries()).map(([value, name]) => ({ value, name }));
+  }, [features]);
+
+  const filteredFeatures = useMemo(
+    () =>
+      features.filter(
+        (f) =>
+          featureStatusFilter === "" ||
+          f.status_details?.value === featureStatusFilter
+      ),
+    [features, featureStatusFilter]
+  );
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -288,6 +316,26 @@ export default function Edit({
             </div>
             <div>
               <Label>Features aus dem gleichen Projekt</Label>
+              {features.length > 0 && (
+                <div className="my-2">
+                  <Select
+                    value={featureStatusFilter}
+                    onValueChange={(value) => setFeatureStatusFilter(value)}
+                  >
+                    <SelectTrigger className="w-[200px]">
+                      <SelectValue placeholder="Status filtern" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">Alle Status</SelectItem>
+                      {statusOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
               <div className="flex flex-wrap gap-2">
                 {features.length === 0 && (
                   <span className="text-sm text-gray-500">Keine Features im Projekt vorhanden.</span>
@@ -299,10 +347,11 @@ export default function Edit({
                         <TableHead className="w-24">Auswählen</TableHead>
                         <TableHead>Jira Key</TableHead>
                         <TableHead>Name</TableHead>
+                        <TableHead>Status</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {features.map((feature) => (
+                      {filteredFeatures.map((feature) => (
                         <TableRow key={feature.id}>
                           <TableCell className="text-center">
                             <input
@@ -314,6 +363,17 @@ export default function Edit({
                           </TableCell>
                           <TableCell>{feature.jira_key}</TableCell>
                           <TableCell>{feature.name}</TableCell>
+                          <TableCell>
+                            {feature.status_details ? (
+                              <span
+                                className={`inline-block px-2 py-1 rounded-md text-xs ${feature.status_details.color}`}
+                              >
+                                {feature.status_details.name}
+                              </span>
+                            ) : (
+                              "-"
+                            )}
+                          </TableCell>
                         </TableRow>
                       ))}
                     </TableBody>


### PR DESCRIPTION
## Summary
- show feature status when editing a planning and allow filtering by status
- deliver feature status details from controller for planning edit form

## Testing
- `npm run lint` (fails: Unexpected any... etc.)
- `npm run types` (fails: All declarations of 'planned_at' must have identical modifiers, ...)
- `composer test` (fails: require vendor/autoload.php failed)


------
https://chatgpt.com/codex/tasks/task_e_68b16942bbcc8325aa18e9de5cac569e