### PR TITLE
Display and filter feature status when editing planning

### DIFF
--- a/app/Http/Controllers/PlanningController.php
+++ b/app/Http/Controllers/PlanningController.php
@@ -120,7 +120,15 @@ class PlanningController extends Controller
     public function edit(Planning $planning)
     {
         $users = User::all(['id', 'name', 'email']); // E-Mail für alle Benutzer hinzugefügt
-        $features = Feature::where('project_id', $planning->project_id)->get(); // Features des Projekts laden
+        $features = Feature::where('project_id', $planning->project_id)
+            ->get()
+            ->map(fn($feature) => [
+                'id' => $feature->id,
+                'jira_key' => $feature->jira_key,
+                'name' => $feature->name,
+                'project_id' => $feature->project_id,
+                'status_details' => $feature->status_details,
+            ])->values(); // Features des Projekts laden
 
         return Inertia::render('plannings/edit', [
             'planning' => $planning->load([


### PR DESCRIPTION
## Summary
- show feature status when editing a planning and allow filtering by status
- deliver feature status details from controller for planning edit form
- avoid empty Select.Item value by using 'all' sentinel and clearing logic
- consolidate duplicate Planning date fields for cleaner types

## Testing
- `npm run lint` (fails: Unexpected any, unused vars, etc.)
- `npm run types` (fails: Argument of type '"plannings.destroy"' is not assignable..., etc.)
- `composer test` (fails: No application encryption key has been specified.)


------
https://chatgpt.com/codex/tasks/task_e_68b16942bbcc8325aa18e9de5cac569e