### PR TITLE
Handle tenant invitation acceptance for unauthenticated users

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\TenantInvitation;
 use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -32,6 +33,31 @@ class AuthenticatedSessionController extends Controller
         $request->authenticate();
 
         $request->session()->regenerate();
+
+        $user = $request->user();
+        $token = $request->session()->pull('tenant_invitation_token');
+
+        if ($token && $user) {
+            $invitation = TenantInvitation::where('token', $token)
+                ->whereNull('accepted_at')
+                ->where(function ($q) {
+                    $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+                })
+                ->first();
+
+            if (!$invitation) {
+                $request->session()->flash('error', 'Die Einladung ist ungültig oder abgelaufen.');
+            } elseif ($invitation->email !== $user->email) {
+                $request->session()->flash('error', 'Die Einladung ist für eine andere E-Mail-Adresse bestimmt.');
+            } elseif (!$user->hasVerifiedEmail()) {
+                // Einladung erneut im Session-State speichern, damit sie nach der Verifizierung angenommen werden kann
+                $request->session()->put('tenant_invitation_token', $token);
+                $request->session()->flash('error', 'Bitte verifiziere deine E-Mail-Adresse, um die Einladung anzunehmen.');
+            } else {
+                $invitation->acceptFor($user);
+                $request->session()->flash('success', 'Einladung akzeptiert und Tenant gewechselt.');
+            }
+        }
 
         return redirect()->intended(route('dashboard', absolute: false));
     }

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -16,7 +16,7 @@ class TenantController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware(['auth', 'verified'])->except('accept');
     }
 
     public function index(): Response
@@ -97,24 +97,34 @@ class TenantController extends Controller
         ]);
 
         $inv = TenantInvitation::where('token', $request->token)
+            ->whereNull('accepted_at')
             ->where(function ($q) {
                 $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
             })
             ->firstOrFail();
 
+        if (!Auth::check()) {
+            $request->session()->put('tenant_invitation_token', $inv->token);
+
+            return redirect()->route('login')->with('status', 'Bitte melde dich an, um die Einladung anzunehmen.');
+        }
+
+        /** @var \App\Models\User $user */
         $user = Auth::user();
+
+        if (!$user->hasVerifiedEmail()) {
+            $request->session()->put('tenant_invitation_token', $inv->token);
+
+            return redirect()->route('verification.notice');
+        }
+
         if ($inv->email !== $user->email) {
             abort(403, 'Invitation is for a different email');
         }
 
-        // Mitgliedschaft hinzufügen
-        $user->tenants()->syncWithoutDetaching([$inv->tenant_id]);
-        $inv->accepted_at = now();
-        $inv->save();
+        $inv->acceptFor($user);
 
-        // Optional: direkt zu diesem Tenant wechseln
-        $user->current_tenant_id = $inv->tenant_id;
-        $user->save();
+        $request->session()->forget('tenant_invitation_token');
 
         return back()->with('success', 'Einladung akzeptiert und Tenant gewechselt.');
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,8 +101,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('tenants', [TenantController::class, 'index'])->name('tenants.index');
     Route::post('tenants/{tenant}/switch', [TenantController::class, 'switch'])->name('tenants.switch');
     Route::post('tenants/{tenant}/invite', [TenantController::class, 'invite'])->name('tenants.invite');
-    Route::post('tenants/accept', [TenantController::class, 'accept'])->name('tenants.accept');
 });
+
+Route::post('tenants/accept', [TenantController::class, 'accept'])->name('tenants.accept');
 
 require __DIR__ . '/settings.php';
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## Summary
- allow tenant invitation acceptance without requiring the authenticated route group
- defer invitation processing until after login and email verification when necessary
- centralize invitation acceptance logic on the model for reuse and transactional safety

## Testing
- php artisan test *(fails: Class "LakM\\Commenter\\Models\\Comment" not found during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68d394f176348325bfacf1462504832c