### PR TITLE
Set stakeholder voting overview collapsed by default

### DIFF
--- a/resources/js/pages/plannings/components/StakeholderTable.tsx
+++ b/resources/js/pages/plannings/components/StakeholderTable.tsx
@@ -16,7 +16,7 @@ interface StakeholderTableProps {
 }
 
 const StakeholderTable = ({ stakeholders }: StakeholderTableProps) => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   // Prüfen, ob Stakeholder-Daten vorhanden sind
   if (!stakeholders || stakeholders.length === 0) {
     return <div className="py-2">Keine Stakeholder vorhanden.</div>;


### PR DESCRIPTION
## Summary
* collapse the stakeholder voting overview by default on the planning details card

## Testing
* npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42bb2c34c83258e44fd45f37de9d4