### PR TITLE
Allow accepting tenant invitations without email verification

### DIFF
--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -133,12 +133,6 @@ class TenantController extends Controller
         /** @var \App\Models\User $user */
         $user = Auth::user();
 
-        if (!$user->hasVerifiedEmail()) {
-            $request->session()->put('tenant_invitation_token', $inv->token);
-
-            return redirect()->route('verification.notice');
-        }
-
         if ($inv->email !== $user->email) {
             abort(403, 'Invitation is for a different email');
         }


### PR DESCRIPTION
## Summary
- remove the email verification gate when accepting a tenant invitation so logged-in users can join immediately

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d39665688325abc507f2fdf84e2d