### PR TITLE
Add Jira issue links to voting session dialogs

### DIFF
--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -108,7 +108,8 @@ class VoteController extends Controller
 
         // Korrekt: nur die Features, die mit dem Planning verknüpft sind
         $features = $planning->features()
-            ->select('features.id', 'features.jira_key', 'features.name', 'features.description')
+            ->select('features.id', 'features.jira_key', 'features.name', 'features.description', 'features.project_id')
+            ->with('project:id,jira_base_uri')
             ->get();
 
         // Bereits abgegebene Votes des Users für dieses Planning laden
@@ -262,7 +263,8 @@ class VoteController extends Controller
 
         // Features laden, die mit dem Planning verknüpft sind
         $features = $planning->features()
-            ->select('features.id', 'features.jira_key', 'features.name', 'features.description')
+            ->select('features.id', 'features.jira_key', 'features.name', 'features.description', 'features.project_id')
+            ->with('project:id,jira_base_uri')
             ->get();
 
         // Bereits abgegebene Votes des Users für dieses Planning laden

--- a/resources/js/pages/votes/card-session.tsx
+++ b/resources/js/pages/votes/card-session.tsx
@@ -29,6 +29,9 @@ interface Feature {
     jira_key: string;
     name: string;
     description?: string;
+    project?: {
+        jira_base_uri?: string | null;
+    } | null;
 }
 
 interface Planning {
@@ -117,8 +120,22 @@ const FeatureCard: React.FC<{
             <Dialog open={showDetails} onOpenChange={setShowDetails}>
                 <DialogContent className="max-w-3xl">
                     <DialogHeader>
-                        <DialogTitle>
-                            {feature.jira_key}: {feature.name}
+                        <DialogTitle className="space-y-1">
+                            <span>
+                                {feature.project?.jira_base_uri ? (
+                                    <a
+                                        href={`${feature.project.jira_base_uri}${feature.jira_key}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 hover:text-blue-800 hover:underline"
+                                    >
+                                        {feature.jira_key}
+                                    </a>
+                                ) : (
+                                    feature.jira_key
+                                )}
+                                {feature.name ? `: ${feature.name}` : ""}
+                            </span>
                         </DialogTitle>
                     </DialogHeader>
 
@@ -216,8 +233,22 @@ const SortableFeatureCard: React.FC<{
             <Dialog open={showDetails} onOpenChange={setShowDetails}>
                 <DialogContent className="max-w-3xl">
                     <DialogHeader>
-                        <DialogTitle>
-                            {feature.jira_key}: {feature.name}
+                        <DialogTitle className="space-y-1">
+                            <span>
+                                {feature.project?.jira_base_uri ? (
+                                    <a
+                                        href={`${feature.project.jira_base_uri}${feature.jira_key}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 hover:text-blue-800 hover:underline"
+                                    >
+                                        {feature.jira_key}
+                                    </a>
+                                ) : (
+                                    feature.jira_key
+                                )}
+                                {feature.name ? `: ${feature.name}` : ""}
+                            </span>
                         </DialogTitle>
                     </DialogHeader>
 
@@ -257,6 +288,10 @@ const CategoryTabContent: React.FC<{
 
     // Zustand für die Detailanzeige
     const [showDetails, setShowDetails] = useState<number | null>(null);
+
+    const detailFeature = showDetails !== null
+        ? categorizedFeatures[type]?.unsorted.find(f => f.id === showDetails) ?? null
+        : null;
 
     // State nicht nötig, da wir direkt die onDragEnd-Funktion aufrufen
     const handleMoveToSorted = (featureId: number) => {
@@ -411,18 +446,32 @@ const CategoryTabContent: React.FC<{
                 </DndContext>
                 
                 {/* Details-Dialog für unbewertete Features */}
-                {showDetails && (
+                {showDetails && detailFeature && (
                     <Dialog open={showDetails !== null} onOpenChange={() => setShowDetails(null)}>
                         <DialogContent className="max-w-3xl">
                             <DialogHeader>
-                                <DialogTitle>
-                                    {categorizedFeatures[type]?.unsorted.find(f => f.id === showDetails)?.jira_key}: {categorizedFeatures[type]?.unsorted.find(f => f.id === showDetails)?.name}
+                                <DialogTitle className="space-y-1">
+                                    <span>
+                                        {detailFeature.project?.jira_base_uri ? (
+                                            <a
+                                                href={`${detailFeature.project.jira_base_uri}${detailFeature.jira_key}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-blue-600 hover:text-blue-800 hover:underline"
+                                            >
+                                                {detailFeature.jira_key}
+                                            </a>
+                                        ) : (
+                                            detailFeature.jira_key
+                                        )}
+                                        {detailFeature.name ? `: ${detailFeature.name}` : ""}
+                                    </span>
                                 </DialogTitle>
                             </DialogHeader>
-                            
+
                             <div className="prose prose-sm max-w-none overflow-auto">
-                                {categorizedFeatures[type]?.unsorted.find(f => f.id === showDetails)?.description ? (
-                                    <div dangerouslySetInnerHTML={{ __html: categorizedFeatures[type]?.unsorted.find(f => f.id === showDetails)?.description || "" }} />
+                                {detailFeature.description ? (
+                                    <div dangerouslySetInnerHTML={{ __html: detailFeature.description }} />
                                 ) : (
                                     <p>Keine Beschreibung vorhanden.</p>
                                 )}

--- a/resources/js/pages/votes/session.tsx
+++ b/resources/js/pages/votes/session.tsx
@@ -14,6 +14,9 @@ interface Feature {
   jira_key: string;
   name: string;
   description?: string;
+  project?: {
+    jira_base_uri?: string | null;
+  } | null;
 }
 
 interface Planning {
@@ -136,8 +139,22 @@ export default function VoteSession({ planning, features, types, existingVotes, 
       <Dialog open={!!selectedFeature} onOpenChange={() => setSelectedFeature(null)}>
         <DialogContent className="max-w-3xl">
           <DialogHeader>
-            <DialogTitle>
-              {selectedFeature?.jira_key}: {selectedFeature?.name}
+            <DialogTitle className="space-y-1">
+              <span>
+                {selectedFeature?.project?.jira_base_uri && selectedFeature?.jira_key ? (
+                  <a
+                    href={`${selectedFeature.project.jira_base_uri}${selectedFeature.jira_key}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:text-blue-800 hover:underline"
+                  >
+                    {selectedFeature.jira_key}
+                  </a>
+                ) : (
+                  selectedFeature?.jira_key
+                )}
+                {selectedFeature?.name ? `: ${selectedFeature.name}` : ""}
+              </span>
             </DialogTitle>
           </DialogHeader>
           


### PR DESCRIPTION
## Summary
- load Jira base URIs with planning features so voting sessions can build Jira links
- expose Jira issue links at the top of the feature detail dialogs in both table and card voting sessions

## Testing
- npm run types *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da641b0a3c8325a4f0870125e3c85e