### PR TITLE
Add feature state history tracking and analytics endpoint

### DIFF
--- a/app/Http/Controllers/FeatureStateHistoryController.php
+++ b/app/Http/Controllers/FeatureStateHistoryController.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Feature;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class FeatureStateHistoryController extends Controller
+{
+    private const DEFAULT_RANGE_DAYS = 90;
+
+    public function index(Request $request): JsonResponse
+    {
+        $from = $request->filled('from')
+            ? Carbon::parse($request->input('from'))->startOfDay()
+            : now()->subDays(self::DEFAULT_RANGE_DAYS)->startOfDay();
+
+        $to = $request->filled('to')
+            ? Carbon::parse($request->input('to'))->endOfDay()
+            : now()->endOfDay();
+
+        if ($from->gt($to)) {
+            [$from, $to] = [$to->copy()->startOfDay(), $from->copy()->endOfDay()];
+        }
+
+        $features = Feature::with(['stateHistories' => fn ($query) => $query->orderBy('changed_at')])
+            ->get(['id', 'status', 'created_at']);
+
+        $segmentsByFeature = [];
+
+        foreach ($features as $feature) {
+            $histories = $feature->stateHistories;
+
+            if ($histories->isEmpty()) {
+                $segmentsByFeature[$feature->id] = [[
+                    'status' => $this->normalizeStatus($feature->status) ?? 'in-planning',
+                    'start' => $this->asCarbon($feature->created_at ?? $from),
+                    'end' => null,
+                ]];
+                continue;
+            }
+
+            $currentStatus = null;
+            $currentStart = null;
+            $segments = [];
+
+            foreach ($histories as $history) {
+                if ($currentStatus !== null && $currentStart !== null) {
+                    $segments[] = [
+                        'status' => $currentStatus,
+                        'start' => $this->asCarbon($currentStart),
+                        'end' => $this->asCarbon($history->changed_at),
+                    ];
+                }
+
+                $currentStatus = $history->to_status;
+                $currentStart = $history->changed_at;
+            }
+
+            if ($currentStatus !== null && $currentStart !== null) {
+                $segments[] = [
+                    'status' => $currentStatus,
+                    'start' => $this->asCarbon($currentStart),
+                    'end' => null,
+                ];
+            }
+
+            $segmentsByFeature[$feature->id] = $segments;
+        }
+
+        $statusKeys = [
+            'in-planning',
+            'approved',
+            'rejected',
+            'implemented',
+            'obsolete',
+            'archived',
+            'deleted',
+        ];
+
+        $timeline = [];
+        $cursor = $from->copy();
+
+        while ($cursor->lte($to)) {
+            $dayEnd = $cursor->copy()->endOfDay();
+            $counts = array_fill_keys($statusKeys, 0);
+
+            foreach ($segmentsByFeature as $segments) {
+                foreach ($segments as $segment) {
+                    /** @var CarbonInterface $segmentStart */
+                    $segmentStart = $segment['start'];
+                    /** @var CarbonInterface|null $segmentEnd */
+                    $segmentEnd = $segment['end'];
+
+                    $isActive = $segmentStart->lte($dayEnd) && ($segmentEnd === null || $segmentEnd->gt($dayEnd));
+
+                    if ($isActive) {
+                        if (! array_key_exists($segment['status'], $counts)) {
+                            $counts[$segment['status']] = 0;
+                        }
+                        $counts[$segment['status']] = ($counts[$segment['status']] ?? 0) + 1;
+                        break;
+                    }
+                }
+            }
+
+            $timeline[] = [
+                'date' => $cursor->toDateString(),
+                'counts' => $counts,
+            ];
+
+            $cursor->addDay();
+        }
+
+        return response()->json([
+            'from' => $from->toISOString(),
+            'to' => $to->toISOString(),
+            'timeline' => $timeline,
+        ]);
+    }
+
+    private function normalizeStatus(mixed $status): ?string
+    {
+        if (is_object($status) && method_exists($status, 'getValue')) {
+            return $status->getValue();
+        }
+
+        if (is_string($status)) {
+            return $status;
+        }
+
+        return null;
+    }
+
+    private function asCarbon(mixed $value): CarbonInterface
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value;
+        }
+
+        return Carbon::parse($value);
+    }
+}

--- a/app/Models/Feature.php
+++ b/app/Models/Feature.php
@@ -16,6 +16,7 @@ use App\States\Feature\Archived;
 use App\States\Feature\Deleted;
 use App\Models\Concerns\BelongsToTenant;
 use App\Models\FeatureDependency;
+use App\Models\FeatureStateHistory;
 
 class Feature extends Model
 {
@@ -109,6 +110,11 @@ class Feature extends Model
     public function votes()
     {
         return $this->hasMany(Vote::class);
+    }
+
+    public function stateHistories(): HasMany
+    {
+        return $this->hasMany(FeatureStateHistory::class)->orderBy('changed_at');
     }
 
     /**

--- a/app/Models/FeatureStateHistory.php
+++ b/app/Models/FeatureStateHistory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FeatureStateHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'feature_id',
+        'tenant_id',
+        'from_status',
+        'to_status',
+        'changed_at',
+    ];
+
+    protected $casts = [
+        'changed_at' => 'datetime',
+    ];
+
+    public function feature(): BelongsTo
+    {
+        return $this->belongsTo(Feature::class);
+    }
+}

--- a/app/Observers/FeatureObserver.php
+++ b/app/Observers/FeatureObserver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Feature;
+use App\Models\FeatureStateHistory;
+use Carbon\CarbonInterface;
+
+class FeatureObserver
+{
+    public function created(Feature $feature): void
+    {
+        $status = $this->normalizeStatus($feature->status);
+
+        FeatureStateHistory::create([
+            'feature_id' => $feature->id,
+            'tenant_id' => $feature->tenant_id,
+            'from_status' => null,
+            'to_status' => $status ?? 'in-planning',
+            'changed_at' => $this->resolveTimestamp($feature->created_at),
+        ]);
+    }
+
+    public function updated(Feature $feature): void
+    {
+        if (! $feature->wasChanged('status')) {
+            return;
+        }
+
+        FeatureStateHistory::create([
+            'feature_id' => $feature->id,
+            'tenant_id' => $feature->tenant_id,
+            'from_status' => $this->normalizeStatus($feature->getOriginal('status')),
+            'to_status' => $this->normalizeStatus($feature->status) ?? 'in-planning',
+            'changed_at' => $this->resolveTimestamp($feature->updated_at),
+        ]);
+    }
+
+    private function normalizeStatus(mixed $status): ?string
+    {
+        if (is_object($status) && method_exists($status, 'getValue')) {
+            return $status->getValue();
+        }
+
+        if (is_string($status)) {
+            return $status;
+        }
+
+        return null;
+    }
+
+    private function resolveTimestamp(mixed $timestamp): CarbonInterface
+    {
+        if ($timestamp instanceof CarbonInterface) {
+            return $timestamp;
+        }
+
+        return now();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,7 +5,9 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
 use App\Models\Estimation;
+use App\Models\Feature;
 use App\Observers\EstimationObserver;
+use App\Observers\FeatureObserver;
 use Spatie\Permission\PermissionRegistrar;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,6 +23,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Estimation::observe(EstimationObserver::class);
+        Feature::observe(FeatureObserver::class);
 
         // Force HTTPS in production
         if (config('app.env') !== 'local') {

--- a/database/migrations/2025_09_15_120000_create_feature_state_histories_table.php
+++ b/database/migrations/2025_09_15_120000_create_feature_state_histories_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('feature_state_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('feature_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tenant_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('from_status')->nullable();
+            $table->string('to_status');
+            $table->timestamp('changed_at')->useCurrent();
+            $table->timestamps();
+
+            $table->index(['feature_id', 'changed_at']);
+            $table->index('to_status');
+        });
+
+        DB::table('features')->select('id', 'tenant_id', 'status', 'created_at')->orderBy('id')->chunkById(500, function ($features) {
+            $historyRows = [];
+
+            foreach ($features as $feature) {
+                $changedAt = $feature->created_at ?? now();
+
+                $historyRows[] = [
+                    'feature_id' => $feature->id,
+                    'tenant_id' => $feature->tenant_id,
+                    'from_status' => null,
+                    'to_status' => $feature->status ?? 'in-planning',
+                    'changed_at' => $changedAt,
+                    'created_at' => $changedAt,
+                    'updated_at' => $changedAt,
+                ];
+            }
+
+            if (! empty($historyRows)) {
+                DB::table('feature_state_histories')->insert($historyRows);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('feature_state_histories');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\PlanningController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\FeatureController;
 use App\Http\Controllers\FeatureDependencyController;
+use App\Http\Controllers\FeatureStateHistoryController;
 use App\Http\Controllers\VoteController;
 use App\Http\Controllers\EstimationComponentController;
 use App\Http\Controllers\FeatureImportController;
@@ -69,6 +70,8 @@ Route::get('features/board', [FeatureController::class, 'board'])->name('feature
 Route::post('features/{feature}/status', [FeatureController::class, 'updateStatus'])->name('features.status.update');
 Route::get('features/lineage', [FeatureController::class, 'lineage'])->name('features.lineage');
 Route::resource('features', FeatureController::class);
+Route::get('api/features/state-history', [FeatureStateHistoryController::class, 'index'])
+    ->name('api.features.state-history');
 // Feature-Abhängigkeiten
 Route::post('features/{feature}/dependencies', [FeatureDependencyController::class, 'store'])->name('features.dependencies.store');
 Route::delete('features/{feature}/dependencies/{dependency}', [FeatureDependencyController::class, 'destroy'])->name('features.dependencies.destroy');


### PR DESCRIPTION
## Summary
- create a dedicated feature_state_histories table and backfill existing records for transition auditing
- observe feature lifecycle events to capture status changes and expose the relationship on the model
- add an authenticated API endpoint that returns historical status timelines for analysis

## Testing
- php artisan test *(fails: vendor directory missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf8fdad508325bb6c647f04665171